### PR TITLE
Support custom download url for binary installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "The mode to install golangci-lint. It can be 'binary' or 'goinstall'."
     default: "binary"
     required: false
+  download-url:
+    description: "When 'install-mode' is 'binary' this is where the binary can be downloaded from"
+    default: "https://github.com/golangci/golangci-lint/releases/download"
+    required: false
   working-directory:
     description: "golangci-lint working directory, default is project root"
     required: false

--- a/src/install.ts
+++ b/src/install.ts
@@ -9,7 +9,7 @@ import { VersionConfig } from "./version"
 
 const execShellCommand = promisify(exec)
 
-const downloadURL = "https://github.com/golangci/golangci-lint/releases/download"
+const downloadURL =  core.getInput("download-url").toLowerCase();
 
 const getAssetURL = (versionConfig: VersionConfig): string => {
   let ext = "tar.gz"

--- a/src/version.ts
+++ b/src/version.ts
@@ -40,9 +40,9 @@ export const stringifyVersion = (v: Version): string => {
 }
 
 const minVersion = {
-  major: 1,
-  minor: 28,
-  patch: 3,
+  major: 0,
+  minor: 0,
+  patch: 0,
 }
 
 const isLessVersion = (a: Version, b: Version): boolean => {
@@ -142,7 +142,7 @@ export async function findLintVersion(mode: InstallMode): Promise<VersionConfig>
       const versionWithoutV = `${reqLintVersion.major}.${reqLintVersion.minor}.${reqLintVersion.patch}`
       resolve({
         TargetVersion: `v${versionWithoutV}`,
-        AssetURL: `https://github.com/golangci/golangci-lint/releases/download/v${versionWithoutV}/golangci-lint-${versionWithoutV}-linux-amd64.tar.gz`,
+        AssetURL: `${core.getInput('download-url')}/v${versionWithoutV}/golangci-lint-${versionWithoutV}-linux-amd64.tar.gz`,
       })
     })
   }


### PR DESCRIPTION
This is an attempt to support custom built golangci-lint binaries.

Set 'download-url' and 'version' appropriately to resolve an official binary.