### PR TITLE
attempt to use existing golangci-lint binary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,16 @@ inputs:
       The version of golangci-lint to use.
       When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
       When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+      When `install-mode` is `none` it is ignored.
     required: false
   install-mode:
-    description: "The mode to install golangci-lint. It can be 'binary' or 'goinstall'."
+    description: "The mode to install golangci-lint. It can be 'binary', 'goinstall', 'none'."
     default: "binary"
+    required: false
+  install-path:
+    description: |
+      When `install-mode` is `none` this is the location of the `golangci-lint` binary, if not set system path will be 
+      used.
     required: false
   working-directory:
     description: "golangci-lint working directory, default is project root"
@@ -22,23 +28,23 @@ inputs:
     required: false
   only-new-issues:
     description: "if set to true and the action runs on a pull request - the action outputs only newly found issues"
-    default: 'false'
+    default: "false"
     required: false
   skip-cache:
     description: |
       if set to true then the all caching functionality will be complete disabled,
       takes precedence over all other caching options.
-    default: 'false'
+    default: "false"
     required: false
   skip-save-cache:
     description: |
       if set to true then the action will not save any caches, but it may still
       restore existing caches, subject to other options.
-    default: 'false'
+    default: "false"
     required: false
   problem-matchers:
     description: "Force the usage of the embedded problem matchers"
-    default: 'false'
+    default: "false"
     required: false
   args:
     description: "golangci-lint command line arguments"
@@ -46,7 +52,7 @@ inputs:
     required: false
   cache-invalidation-interval:
     description: "Periodically invalidate a cache because a new code being added. (number of days)"
-    default: '7'
+    default: "7"
     required: false
 runs:
   using: "node20"

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -85114,6 +85114,7 @@ exports.InstallMode = void 0;
 exports.installLint = installLint;
 exports.goInstall = goInstall;
 exports.installBin = installBin;
+exports.noneInstall = noneInstall;
 const core = __importStar(__nccwpck_require__(2186));
 const tc = __importStar(__nccwpck_require__(7784));
 const child_process_1 = __nccwpck_require__(2081);
@@ -85148,6 +85149,7 @@ var InstallMode;
 (function (InstallMode) {
     InstallMode["Binary"] = "binary";
     InstallMode["GoInstall"] = "goinstall";
+    InstallMode["None"] = "none";
 })(InstallMode || (exports.InstallMode = InstallMode = {}));
 const printOutput = (res) => {
     if (res.stdout) {
@@ -85171,6 +85173,8 @@ async function installLint(versionConfig, mode) {
             return installBin(versionConfig);
         case InstallMode.GoInstall:
             return goInstall(versionConfig);
+        case InstallMode.None:
+            return noneInstall();
         default:
             return installBin(versionConfig);
     }
@@ -85225,6 +85229,21 @@ async function installBin(versionConfig) {
     const lintPath = path_1.default.join(extractedDir, dirName, `golangci-lint`);
     core.info(`Installed golangci-lint into ${lintPath} in ${Date.now() - startedAt}ms`);
     return lintPath;
+}
+/**
+ * golangci-lint binary is already present on host
+ *
+ * @returns path to installed binary of golangci-lint.
+ */
+async function noneInstall() {
+    core.info(`Referencing pre-installed golangci-lint binary`);
+    const providedPath = core.getInput(`install-path`);
+    if (providedPath) {
+        core.info(`Path has been provided ${providedPath} ...`);
+        return providedPath;
+    }
+    core.info(`Path has not been provided, using system path`);
+    return "golangci-lint";
 }
 
 
@@ -85785,6 +85804,9 @@ async function findLintVersion(mode) {
     if (mode == install_1.InstallMode.GoInstall) {
         const v = core.getInput(`version`);
         return { TargetVersion: v ? v : "latest", AssetURL: "github.com/golangci/golangci-lint" };
+    }
+    if (mode == install_1.InstallMode.None) {
+        return { TargetVersion: "", AssetURL: "" };
     }
     const reqLintVersion = getRequestedLintVersion();
     // if the patched version is passed, just use it

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -85114,6 +85114,7 @@ exports.InstallMode = void 0;
 exports.installLint = installLint;
 exports.goInstall = goInstall;
 exports.installBin = installBin;
+exports.noneInstall = noneInstall;
 const core = __importStar(__nccwpck_require__(2186));
 const tc = __importStar(__nccwpck_require__(7784));
 const child_process_1 = __nccwpck_require__(2081);
@@ -85148,6 +85149,7 @@ var InstallMode;
 (function (InstallMode) {
     InstallMode["Binary"] = "binary";
     InstallMode["GoInstall"] = "goinstall";
+    InstallMode["None"] = "none";
 })(InstallMode || (exports.InstallMode = InstallMode = {}));
 const printOutput = (res) => {
     if (res.stdout) {
@@ -85171,6 +85173,8 @@ async function installLint(versionConfig, mode) {
             return installBin(versionConfig);
         case InstallMode.GoInstall:
             return goInstall(versionConfig);
+        case InstallMode.None:
+            return noneInstall();
         default:
             return installBin(versionConfig);
     }
@@ -85225,6 +85229,21 @@ async function installBin(versionConfig) {
     const lintPath = path_1.default.join(extractedDir, dirName, `golangci-lint`);
     core.info(`Installed golangci-lint into ${lintPath} in ${Date.now() - startedAt}ms`);
     return lintPath;
+}
+/**
+ * golangci-lint binary is already present on host
+ *
+ * @returns path to installed binary of golangci-lint.
+ */
+async function noneInstall() {
+    core.info(`Referencing pre-installed golangci-lint binary`);
+    const providedPath = core.getInput(`install-path`);
+    if (providedPath) {
+        core.info(`Path has been provided ${providedPath} ...`);
+        return providedPath;
+    }
+    core.info(`Path has not been provided, using system path`);
+    return "golangci-lint";
 }
 
 
@@ -85785,6 +85804,9 @@ async function findLintVersion(mode) {
     if (mode == install_1.InstallMode.GoInstall) {
         const v = core.getInput(`version`);
         return { TargetVersion: v ? v : "latest", AssetURL: "github.com/golangci/golangci-lint" };
+    }
+    if (mode == install_1.InstallMode.None) {
+        return { TargetVersion: "", AssetURL: "" };
     }
     const reqLintVersion = getRequestedLintVersion();
     // if the patched version is passed, just use it

--- a/src/install.ts
+++ b/src/install.ts
@@ -38,6 +38,7 @@ const getAssetURL = (versionConfig: VersionConfig): string => {
 export enum InstallMode {
   Binary = "binary",
   GoInstall = "goinstall",
+  None = "none"
 }
 
 type ExecRes = {
@@ -69,6 +70,8 @@ export async function installLint(versionConfig: VersionConfig, mode: InstallMod
       return installBin(versionConfig)
     case InstallMode.GoInstall:
       return goInstall(versionConfig)
+    case InstallMode.None:
+        return noneInstall()
     default:
       return installBin(versionConfig)
   }
@@ -145,4 +148,23 @@ export async function installBin(versionConfig: VersionConfig): Promise<string> 
   core.info(`Installed golangci-lint into ${lintPath} in ${Date.now() - startedAt}ms`)
 
   return lintPath
+}
+
+/**
+ * golangci-lint binary is already present on host
+ *
+ * @returns path to installed binary of golangci-lint.
+ */
+export async function noneInstall(): Promise<string> {
+  core.info(`Referencing pre-installed golangci-lint binary`)
+
+  const providedPath = core.getInput(`install-path`);
+
+  if (providedPath) {
+    core.info(`Path has been provided ${providedPath} ...`)
+    return providedPath
+  }
+
+  core.info(`Path has not been provided, using system path`)
+  return "golangci-lint"
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -134,6 +134,10 @@ export async function findLintVersion(mode: InstallMode): Promise<VersionConfig>
     return { TargetVersion: v ? v : "latest", AssetURL: "github.com/golangci/golangci-lint" }
   }
 
+  if (mode == InstallMode.None) {
+    return { TargetVersion: "", AssetURL: ""}
+  }
+
   const reqLintVersion = getRequestedLintVersion()
 
   // if the patched version is passed, just use it


### PR DESCRIPTION
new `install-mode` being `none`, which won't download or install `golangci-lint`. Optionally can provide `install-path` which is the directory containing the pre-installed `golangci-lint` binary.