### PR TITLE
[IR-89] Uplifting action version and SHA Pinning

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -31,7 +31,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
         # Override language selection by uncommenting this and choosing your languages
         with:
           language: 'javascript'
@@ -41,4 +41,4 @@ jobs:
           npm run all
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13


### PR DESCRIPTION
This PR pins workflow actions to the SHA to prevent issues with supply chain attacks repointing tags under the hood. It also update the version to a consistent SHA across the organisation